### PR TITLE
Use dependency-groups instead of project.optional-dependencies for local dev-deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-permissions: read-all
-
 env:
   UV_FROZEN: 1
 
@@ -26,7 +24,7 @@ jobs:
           enable-cache: true
 
       - name: Install deps
-        run: uv sync --all-extras
+        run: uv sync
 
       - name: Toolchain caching
         uses: actions/cache@v4
@@ -69,7 +67,7 @@ jobs:
         run: uv python pin "${{ matrix.python-version }}"
 
       - name: Install deps
-        run: uv sync --all-extras
+        run: uv sync
 
       - name: Run tests
         run: uv run nox

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,8 @@ on:
   push:
     tags: [v*]
 
-permissions: read-all
+env:
+  UV_FROZEN: 1
 
 jobs:
   release:
@@ -23,7 +24,7 @@ jobs:
           enable-cache: true
 
       - name: Install deps
-        run: uv sync --frozen --all-extras
+        run: uv sync
 
       - name: Build package
         run: uv build

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,9 +23,6 @@ def tests(
     *,
     extras: list[str],
 ) -> None:
-    # Test dependencies are required and always installed
-    extras.extend(["dev", "test"])
-
     # Run the tests via `uv`
     session.run_install("uv", "sync", "--quiet", *[f"--extra={extra}" for extra in extras])
     session.run("uv", "run", "pytest", "--cov-append")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,11 @@ requires-python = ">=3.9, <4.0"
 dependencies = ["braceexpand>=0.1.7,<1", "jinja2>=3,<4", "pulumi>=3,<4"]
 
 [project.optional-dependencies]
+policy = ["pulumi-policy>=1,<2"]
+aws = ["pulumi-aws>=6"]
+gcp = ["pulumi-gcp>=8"]
+
+[dependency-groups]
 dev = ["mypy~=1.11", "ruff~=0.6"]
 test = [
 	"coverage~=7.3",
@@ -20,9 +25,6 @@ test = [
 	"pulumi-docker>=4.6.1",
 	"pytest-forked>=1.6.0",
 ]
-policy = ["pulumi-policy>=1,<2"]
-aws = ["pulumi-aws>=6"]
-gcp = ["pulumi-gcp>=8"]
 
 [project.urls]
 Homepage = "https://github.com/lasuillard/pulumi-extra"
@@ -32,6 +34,9 @@ Issues = "https://github.com/lasuillard/pulumi-extra/issues"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.uv]
+default-groups = ["dev", "test"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["pulumi_extra"]
@@ -77,9 +82,7 @@ addopts = [
 	"-rs",
 ]
 testpaths = ["tests"]
-markers = [
-	"integration: mark a test as an integration test",
-]
+markers = ["integration: mark a test as an integration test"]
 
 [tool.coverage.run]
 include = ["pulumi_extra/*"]

--- a/uv.lock
+++ b/uv.lock
@@ -570,15 +570,17 @@ dependencies = [
 aws = [
     { name = "pulumi-aws" },
 ]
-dev = [
-    { name = "mypy" },
-    { name = "ruff" },
-]
 gcp = [
     { name = "pulumi-gcp" },
 ]
 policy = [
     { name = "pulumi-policy" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
 ]
 test = [
     { name = "coverage" },
@@ -594,23 +596,29 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "braceexpand", specifier = ">=0.1.7,<1" },
-    { name = "coverage", marker = "extra == 'test'", specifier = "~=7.3" },
     { name = "jinja2", specifier = ">=3,<4" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = "~=1.11" },
-    { name = "nox", marker = "extra == 'test'", specifier = ">=2024.10.9,<2025.3.0" },
     { name = "pulumi", specifier = ">=3,<4" },
     { name = "pulumi-aws", marker = "extra == 'aws'", specifier = ">=6" },
-    { name = "pulumi-docker", marker = "extra == 'test'", specifier = ">=4.6.1" },
     { name = "pulumi-gcp", marker = "extra == 'gcp'", specifier = ">=8" },
     { name = "pulumi-policy", marker = "extra == 'policy'", specifier = ">=1,<2" },
-    { name = "pulumi-random", marker = "extra == 'test'", specifier = ">=4.18.0" },
-    { name = "pytest", marker = "extra == 'test'", specifier = "~=8.0" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=5,<7" },
-    { name = "pytest-forked", marker = "extra == 'test'", specifier = ">=1.6.0" },
-    { name = "pytest-sugar", marker = "extra == 'test'", specifier = "~=1.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "~=0.6" },
 ]
-provides-extras = ["dev", "test", "policy", "aws", "gcp"]
+provides-extras = ["policy", "aws", "gcp"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = "~=1.11" },
+    { name = "ruff", specifier = "~=0.6" },
+]
+test = [
+    { name = "coverage", specifier = "~=7.3" },
+    { name = "nox", specifier = ">=2024.10.9,<2025.3.0" },
+    { name = "pulumi-docker", specifier = ">=4.6.1" },
+    { name = "pulumi-random", specifier = ">=4.18.0" },
+    { name = "pytest", specifier = "~=8.0" },
+    { name = "pytest-cov", specifier = ">=5,<7" },
+    { name = "pytest-forked", specifier = ">=1.6.0" },
+    { name = "pytest-sugar", specifier = "~=1.0" },
+]
 
 [[package]]
 name = "pulumi-gcp"


### PR DESCRIPTION
Use `dependency-groups` and `tool.uv.default-groups` to manage local development dependencies instead of `project.optional-dependencies`.